### PR TITLE
Add Booking Tag (previously Date Tag)

### DIFF
--- a/src/main/java/seedu/innsync/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/innsync/logic/commands/EditCommand.java
@@ -26,7 +26,7 @@ import seedu.innsync.model.person.Email;
 import seedu.innsync.model.person.Name;
 import seedu.innsync.model.person.Person;
 import seedu.innsync.model.person.Phone;
-import seedu.innsync.model.tag.DateTag;
+import seedu.innsync.model.tag.BookingTag;
 import seedu.innsync.model.tag.Tag;
 
 /**
@@ -100,9 +100,11 @@ public class EditCommand extends Command {
         Phone updatedPhone = editPersonDescriptor.getPhone().orElse(personToEdit.getPhone());
         Email updatedEmail = editPersonDescriptor.getEmail().orElse(personToEdit.getEmail());
         Address updatedAddress = editPersonDescriptor.getAddress().orElse(personToEdit.getAddress());
+        Set<BookingTag> updatedBookingTags =
+            editPersonDescriptor.getBookingTags().orElse(personToEdit.getBookingTags());
         Set<Tag> updatedTags = editPersonDescriptor.getTags().orElse(personToEdit.getTags());
 
-        return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedTags);
+        return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedBookingTags, updatedTags);
     }
 
     @Override
@@ -138,6 +140,7 @@ public class EditCommand extends Command {
         private Phone phone;
         private Email email;
         private Address address;
+        private Set<BookingTag> bookingTags;
         private Set<Tag> tags;
 
         public EditPersonDescriptor() {}
@@ -151,6 +154,7 @@ public class EditCommand extends Command {
             setPhone(toCopy.phone);
             setEmail(toCopy.email);
             setAddress(toCopy.address);
+            setBookingTags(toCopy.bookingTags);
             setTags(toCopy.tags);
         }
 
@@ -158,7 +162,7 @@ public class EditCommand extends Command {
          * Returns true if at least one field is edited.
          */
         public boolean isAnyFieldEdited() {
-            return CollectionUtil.isAnyNonNull(name, phone, email, address, tags);
+            return CollectionUtil.isAnyNonNull(name, phone, email, address, bookingTags, tags);
         }
 
         public void setName(Name name) {
@@ -191,6 +195,14 @@ public class EditCommand extends Command {
 
         public Optional<Address> getAddress() {
             return Optional.ofNullable(address);
+        }
+
+        public void setBookingTags(Set<BookingTag> bookingTags) {
+            this.bookingTags = (bookingTags != null) ? new HashSet<>(bookingTags) : null;
+        }
+
+        public Optional<Set<BookingTag>> getBookingTags() {
+            return (bookingTags != null) ? Optional.of(Collections.unmodifiableSet(bookingTags)) : Optional.empty();
         }
 
         /**
@@ -226,6 +238,7 @@ public class EditCommand extends Command {
                     && Objects.equals(phone, otherEditPersonDescriptor.phone)
                     && Objects.equals(email, otherEditPersonDescriptor.email)
                     && Objects.equals(address, otherEditPersonDescriptor.address)
+                    && Objects.equals(bookingTags, otherEditPersonDescriptor.bookingTags)
                     && Objects.equals(tags, otherEditPersonDescriptor.tags);
         }
 
@@ -236,6 +249,7 @@ public class EditCommand extends Command {
                     .add("phone", phone)
                     .add("email", email)
                     .add("address", address)
+                    .add("bookingTags", bookingTags)
                     .add("tags", tags)
                     .toString();
         }

--- a/src/main/java/seedu/innsync/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/innsync/logic/commands/EditCommand.java
@@ -26,6 +26,7 @@ import seedu.innsync.model.person.Email;
 import seedu.innsync.model.person.Name;
 import seedu.innsync.model.person.Person;
 import seedu.innsync.model.person.Phone;
+import seedu.innsync.model.tag.DateTag;
 import seedu.innsync.model.tag.Tag;
 
 /**

--- a/src/main/java/seedu/innsync/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/innsync/logic/parser/AddCommandParser.java
@@ -17,6 +17,7 @@ import seedu.innsync.model.person.Email;
 import seedu.innsync.model.person.Name;
 import seedu.innsync.model.person.Person;
 import seedu.innsync.model.person.Phone;
+import seedu.innsync.model.tag.DateTag;
 import seedu.innsync.model.tag.Tag;
 
 /**
@@ -31,7 +32,9 @@ public class AddCommandParser implements Parser<AddCommand> {
      */
     public AddCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG);
+                ArgumentTokenizer.tokenize(
+                    args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
+                    PREFIX_ADDRESS, PREFIX_DATETAG, PREFIX_TAG);
 
         if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_ADDRESS, PREFIX_PHONE, PREFIX_EMAIL)
                 || !argMultimap.getPreamble().isEmpty()) {

--- a/src/main/java/seedu/innsync/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/innsync/logic/parser/AddCommandParser.java
@@ -17,7 +17,7 @@ import seedu.innsync.model.person.Email;
 import seedu.innsync.model.person.Name;
 import seedu.innsync.model.person.Person;
 import seedu.innsync.model.person.Phone;
-import seedu.innsync.model.tag.DateTag;
+import seedu.innsync.model.tag.BookingTag;
 import seedu.innsync.model.tag.Tag;
 
 /**
@@ -46,9 +46,9 @@ public class AddCommandParser implements Parser<AddCommand> {
         Phone phone = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
         Email email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get());
         Address address = ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get());
+        Set<BookingTag> bookingTagList = ParserUtil.parseBookingTags(argMultimap.getAllValues(PREFIX_DATETAG));
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
-
-        Person person = new Person(name, phone, email, address, tagList);
+        Person person = new Person(name, phone, email, address, bookingTagList, tagList);
 
         return new AddCommand(person);
     }

--- a/src/main/java/seedu/innsync/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/innsync/logic/parser/AddCommandParser.java
@@ -2,6 +2,7 @@ package seedu.innsync.logic.parser;
 
 import static seedu.innsync.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.innsync.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.innsync.logic.parser.CliSyntax.PREFIX_BOOKINGTAG;
 import static seedu.innsync.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.innsync.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.innsync.logic.parser.CliSyntax.PREFIX_PHONE;
@@ -34,7 +35,7 @@ public class AddCommandParser implements Parser<AddCommand> {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(
                     args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
-                    PREFIX_ADDRESS, PREFIX_DATETAG, PREFIX_TAG);
+                    PREFIX_ADDRESS, PREFIX_BOOKINGTAG, PREFIX_TAG);
 
         if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_ADDRESS, PREFIX_PHONE, PREFIX_EMAIL)
                 || !argMultimap.getPreamble().isEmpty()) {
@@ -46,7 +47,7 @@ public class AddCommandParser implements Parser<AddCommand> {
         Phone phone = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
         Email email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get());
         Address address = ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get());
-        Set<BookingTag> bookingTagList = ParserUtil.parseBookingTags(argMultimap.getAllValues(PREFIX_DATETAG));
+        Set<BookingTag> bookingTagList = ParserUtil.parseBookingTags(argMultimap.getAllValues(PREFIX_BOOKINGTAG));
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
         Person person = new Person(name, phone, email, address, bookingTagList, tagList);
 

--- a/src/main/java/seedu/innsync/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/innsync/logic/parser/CliSyntax.java
@@ -10,6 +10,7 @@ public class CliSyntax {
     public static final Prefix PREFIX_PHONE = new Prefix("p/");
     public static final Prefix PREFIX_EMAIL = new Prefix("e/");
     public static final Prefix PREFIX_ADDRESS = new Prefix("a/");
+    public static final Prefix PREFIX_BOOKINGTAG = new Prefix("b/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
 
 }

--- a/src/main/java/seedu/innsync/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/innsync/logic/parser/EditCommandParser.java
@@ -32,7 +32,9 @@ public class EditCommandParser implements Parser<EditCommand> {
     public EditCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG);
+                ArgumentTokenizer.tokenize(
+                    args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
+                    PREFIX_ADDRESS, PREFIX_DATETAG, PREFIX_TAG);
 
         Index index;
 
@@ -80,6 +82,17 @@ public class EditCommandParser implements Parser<EditCommand> {
         }
         Collection<String> tagSet = tags.size() == 1 && tags.contains("") ? Collections.emptySet() : tags;
         return Optional.of(ParserUtil.parseTags(tagSet));
+    }
+
+    private Optional<Set<DateTag>> parseDateTagsForEdit(Collection<String> dateTags) throws ParseException {
+        assert dateTags != null;
+
+        if (dateTags.isEmpty()) {
+            return Optional.empty();
+        }
+        Collection<String> dateTagSet = dateTags.size() == 1 && dateTags.contains("")
+                ? Collections.emptySet() : dateTags;
+        return Optional.of(ParserUtil.parseDateTags(dateTagSet));
     }
 
 }

--- a/src/main/java/seedu/innsync/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/innsync/logic/parser/EditCommandParser.java
@@ -3,6 +3,7 @@ package seedu.innsync.logic.parser;
 import static java.util.Objects.requireNonNull;
 import static seedu.innsync.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.innsync.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.innsync.logic.parser.CliSyntax.PREFIX_BOOKINGTAG;
 import static seedu.innsync.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.innsync.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.innsync.logic.parser.CliSyntax.PREFIX_PHONE;
@@ -35,7 +36,7 @@ public class EditCommandParser implements Parser<EditCommand> {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(
                     args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
-                    PREFIX_ADDRESS, PREFIX_DATETAG, PREFIX_TAG);
+                    PREFIX_ADDRESS, PREFIX_BOOKINGTAG, PREFIX_TAG);
 
         Index index;
 
@@ -62,7 +63,7 @@ public class EditCommandParser implements Parser<EditCommand> {
             editPersonDescriptor.setAddress(ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get()));
         }
 
-        parseBookingTagsForEdit(argMultimap.getAllValues(PREFIX_DATETAG))
+        parseBookingTagsForEdit(argMultimap.getAllValues(PREFIX_BOOKINGTAG))
                 .ifPresent(editPersonDescriptor::setBookingTags);
 
         parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editPersonDescriptor::setTags);

--- a/src/main/java/seedu/innsync/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/innsync/logic/parser/EditCommandParser.java
@@ -17,6 +17,7 @@ import seedu.innsync.commons.core.index.Index;
 import seedu.innsync.logic.commands.EditCommand;
 import seedu.innsync.logic.commands.EditCommand.EditPersonDescriptor;
 import seedu.innsync.logic.parser.exceptions.ParseException;
+import seedu.innsync.model.tag.BookingTag;
 import seedu.innsync.model.tag.Tag;
 
 /**
@@ -60,6 +61,10 @@ public class EditCommandParser implements Parser<EditCommand> {
         if (argMultimap.getValue(PREFIX_ADDRESS).isPresent()) {
             editPersonDescriptor.setAddress(ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get()));
         }
+
+        parseBookingTagsForEdit(argMultimap.getAllValues(PREFIX_DATETAG))
+                .ifPresent(editPersonDescriptor::setBookingTags);
+
         parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editPersonDescriptor::setTags);
 
         if (!editPersonDescriptor.isAnyFieldEdited()) {
@@ -84,15 +89,15 @@ public class EditCommandParser implements Parser<EditCommand> {
         return Optional.of(ParserUtil.parseTags(tagSet));
     }
 
-    private Optional<Set<DateTag>> parseDateTagsForEdit(Collection<String> dateTags) throws ParseException {
-        assert dateTags != null;
+    private Optional<Set<BookingTag>> parseBookingTagsForEdit(Collection<String> bookingTags) throws ParseException {
+        assert bookingTags != null;
 
-        if (dateTags.isEmpty()) {
+        if (bookingTags.isEmpty()) {
             return Optional.empty();
         }
-        Collection<String> dateTagSet = dateTags.size() == 1 && dateTags.contains("")
-                ? Collections.emptySet() : dateTags;
-        return Optional.of(ParserUtil.parseDateTags(dateTagSet));
+        Collection<String> bookingTagSet = bookingTags.size() == 1 && bookingTags.contains("")
+                ? Collections.emptySet() : bookingTags;
+        return Optional.of(ParserUtil.parseBookingTags(bookingTagSet));
     }
 
 }

--- a/src/main/java/seedu/innsync/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/innsync/logic/parser/ParserUtil.java
@@ -13,6 +13,7 @@ import seedu.innsync.model.person.Address;
 import seedu.innsync.model.person.Email;
 import seedu.innsync.model.person.Name;
 import seedu.innsync.model.person.Phone;
+import seedu.innsync.model.tag.DateTag;
 import seedu.innsync.model.tag.Tag;
 
 /**

--- a/src/main/java/seedu/innsync/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/innsync/logic/parser/ParserUtil.java
@@ -13,7 +13,7 @@ import seedu.innsync.model.person.Address;
 import seedu.innsync.model.person.Email;
 import seedu.innsync.model.person.Name;
 import seedu.innsync.model.person.Phone;
-import seedu.innsync.model.tag.DateTag;
+import seedu.innsync.model.tag.BookingTag;
 import seedu.innsync.model.tag.Tag;
 
 /**
@@ -94,6 +94,33 @@ public class ParserUtil {
             throw new ParseException(Email.MESSAGE_CONSTRAINTS);
         }
         return new Email(trimmedEmail);
+    }
+
+    /**
+     * Parses a {@code String bookingTag} into a {@code bookingTag}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code bookingTag} is invalid.
+     */
+    public static BookingTag parseBookingTag(String bookingTag) throws ParseException {
+        requireNonNull(bookingTag);
+        String trimmedBookingTag = bookingTag.trim();
+        if (!Tag.isValidTagName(trimmedBookingTag)) {
+            throw new ParseException(Tag.MESSAGE_CONSTRAINTS);
+        }
+        return new BookingTag(trimmedBookingTag);
+    }
+
+    /**
+     * Parses {@code Collection<String> bookingTags} into a {@code Set<BookingTag>}.
+     */
+    public static Set<BookingTag> parseBookingTags(Collection<String> bookingTags) throws ParseException {
+        requireNonNull(bookingTags);
+        final Set<BookingTag> bookingTagSet = new HashSet<>();
+        for (String bookingTagName : bookingTags) {
+            bookingTagSet.add(parseBookingTag(bookingTagName));
+        }
+        return bookingTagSet;
     }
 
     /**

--- a/src/main/java/seedu/innsync/model/person/Person.java
+++ b/src/main/java/seedu/innsync/model/person/Person.java
@@ -8,6 +8,7 @@ import java.util.Objects;
 import java.util.Set;
 
 import seedu.innsync.commons.util.ToStringBuilder;
+import seedu.innsync.model.tag.BookingTag;
 import seedu.innsync.model.tag.Tag;
 
 /**
@@ -23,17 +24,20 @@ public class Person {
 
     // Data fields
     private final Address address;
+    private final Set<BookingTag> bookingTags = new HashSet<>();
     private final Set<Tag> tags = new HashSet<>();
 
     /**
      * Every field must be present and not null.
      */
-    public Person(Name name, Phone phone, Email email, Address address, Set<Tag> tags) {
-        requireAllNonNull(name, phone, email, address, tags);
+    public Person(Name name, Phone phone, Email email, Address address, Set<BookingTag> bookingTags,
+                  Set<Tag> tags) {
+        requireAllNonNull(name, phone, email, address, bookingTags, tags);
         this.name = name;
         this.phone = phone;
         this.email = email;
         this.address = address;
+        this.bookingTags.addAll(bookingTags);
         this.tags.addAll(tags);
     }
 
@@ -51,6 +55,10 @@ public class Person {
 
     public Address getAddress() {
         return address;
+    }
+
+    public Set<BookingTag> getBookingTags() {
+        return Collections.unmodifiableSet(bookingTags);
     }
 
     /**
@@ -94,13 +102,14 @@ public class Person {
                 && phone.equals(otherPerson.phone)
                 && email.equals(otherPerson.email)
                 && address.equals(otherPerson.address)
+                && bookingTags.equals(otherPerson.bookingTags)
                 && tags.equals(otherPerson.tags);
     }
 
     @Override
     public int hashCode() {
         // use this method for custom fields hashing instead of implementing your own
-        return Objects.hash(name, phone, email, address, tags);
+        return Objects.hash(name, phone, email, address, bookingTags, tags);
     }
 
     @Override
@@ -110,6 +119,7 @@ public class Person {
                 .add("phone", phone)
                 .add("email", email)
                 .add("address", address)
+                .add("bookingTags", bookingTags)
                 .add("tags", tags)
                 .toString();
     }

--- a/src/main/java/seedu/innsync/model/tag/BookingTag.java
+++ b/src/main/java/seedu/innsync/model/tag/BookingTag.java
@@ -8,34 +8,34 @@ import java.time.format.DateTimeFormatter;
 
 /**
  * Represents a Tag in the address book.
- * Guarantees: immutable; name is valid as declared in {@link #isValidDateTagName(String)}
+ * Guarantees: immutable; name is valid as declared in {@link #isValidBookingTagName(String)}
  */
-public class DateTag {
+public class BookingTag {
 
     public static final String MESSAGE_CONSTRAINTS = "Date tag names should in the format of YYYY-MM-DD";
     public static final String VALIDATION_REGEX = "\\d{4}-\\d{2}-\\d{2}";
     private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
 
-    public final LocalDateTime dateTagDate;
-    public final String dateTagName;
+    public final LocalDateTime bookingTagDate;
+    public final String bookingTagName;
 
 
     /**
      * Constructs a {@code Tag}.
      *
-     * @param dateTagName A valid tag name.
+     * @param bookingTagName A valid tag name.
      */
-    public DateTag(String dateTagName) {
-        requireNonNull(dateTagName);
-        checkArgument(isValidDateTagName(dateTagName), MESSAGE_CONSTRAINTS);
-        this.dateTagName = dateTagName;
-        this.dateTagDate = LocalDateTime.parse(dateTagName, DATE_TIME_FORMATTER);
+    public BookingTag(String bookingTagName) {
+        requireNonNull(bookingTagName);
+        checkArgument(isValidBookingTagName(bookingTagName), MESSAGE_CONSTRAINTS);
+        this.bookingTagName = bookingTagName;
+        this.bookingTagDate = LocalDateTime.parse(bookingTagName, DATE_TIME_FORMATTER);
     }
 
     /**
      * Returns true if a given string is a valid tag name.
      */
-    public static boolean isValidDateTagName(String test) {
+    public static boolean isValidBookingTagName(String test) {
         return test.matches(VALIDATION_REGEX);
     }
 
@@ -50,20 +50,20 @@ public class DateTag {
             return false;
         }
 
-        DateTag otherDateTag = (DateTag) other;
-        return dateTagName.equals(otherDateTag.dateTagName);
+        BookingTag otherBookingTag = (BookingTag) other;
+        return bookingTagName.equals(otherBookingTag.bookingTagName);
     }
 
     @Override
     public int hashCode() {
-        return dateTagName.hashCode();
+        return bookingTagName.hashCode();
     }
 
     /**
      * Format state as text for viewing.
      */
     public String toString() {
-        return '[' + dateTagName + ']';
+        return '[' + bookingTagName + ']';
     }
 
 }

--- a/src/main/java/seedu/innsync/model/tag/BookingTag.java
+++ b/src/main/java/seedu/innsync/model/tag/BookingTag.java
@@ -12,13 +12,16 @@ import java.time.format.DateTimeFormatter;
  */
 public class BookingTag {
 
-    public static final String MESSAGE_CONSTRAINTS = "Date tag names should in the format of YYYY-MM-DD";
-    public static final String VALIDATION_REGEX = "\\d{4}-\\d{2}-\\d{2}";
+    public static final String MESSAGE_CONSTRAINTS = "Booking tags should be of the format "
+            + "{property} from/{start-date} to/{end-date} "
+            + "where start-date and end-date are in the format yyyy-MM-dd. "
+            + "The start-date should be before the end-date.";
+    public static final String VALIDATION_REGEX = ".* from/\\d{4}-\\d{2}-\\d{2} to/\\d{4}-\\d{2}-\\d{2}";
     private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
 
-    public final LocalDateTime bookingTagDate;
     public final String bookingTagName;
-
+    public final LocalDateTime startDate;
+    public final LocalDateTime endDate;
 
     /**
      * Constructs a {@code Tag}.
@@ -28,15 +31,25 @@ public class BookingTag {
     public BookingTag(String bookingTagName) {
         requireNonNull(bookingTagName);
         checkArgument(isValidBookingTagName(bookingTagName), MESSAGE_CONSTRAINTS);
+
+        String[] split = bookingTagName.split(" from/| to/");
         this.bookingTagName = bookingTagName;
-        this.bookingTagDate = LocalDateTime.parse(bookingTagName, DATE_TIME_FORMATTER);
+        this.startDate = LocalDateTime.parse(split[1], DATE_TIME_FORMATTER);
+        this.endDate = LocalDateTime.parse(split[2], DATE_TIME_FORMATTER);
     }
 
     /**
      * Returns true if a given string is a valid tag name.
      */
     public static boolean isValidBookingTagName(String test) {
-        return test.matches(VALIDATION_REGEX);
+        if (test.matches(VALIDATION_REGEX)) {
+            String[] split = test.split(" from/| to/");
+            LocalDateTime startDate = LocalDateTime.parse(split[1], DATE_TIME_FORMATTER);
+            LocalDateTime endDate = LocalDateTime.parse(split[2], DATE_TIME_FORMATTER);
+            return startDate.isBefore(endDate);
+        } else {
+            return false;
+        }
     }
 
     @Override

--- a/src/main/java/seedu/innsync/model/tag/DateTag.java
+++ b/src/main/java/seedu/innsync/model/tag/DateTag.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.innsync.commons.util.AppUtil.checkArgument;
 
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 /**
  * Represents a Tag in the address book.
@@ -13,9 +14,11 @@ public class DateTag {
 
     public static final String MESSAGE_CONSTRAINTS = "Date tag names should in the format of YYYY-MM-DD";
     public static final String VALIDATION_REGEX = "\\d{4}-\\d{2}-\\d{2}";
+    private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
 
     public final LocalDateTime dateTagDate;
     public final String dateTagName;
+
 
     /**
      * Constructs a {@code Tag}.
@@ -26,7 +29,7 @@ public class DateTag {
         requireNonNull(dateTagName);
         checkArgument(isValidDateTagName(dateTagName), MESSAGE_CONSTRAINTS);
         this.dateTagName = dateTagName;
-        this.dateTagDate = LocalDateTime.parse(dateTagName);
+        this.dateTagDate = LocalDateTime.parse(dateTagName, DATE_TIME_FORMATTER);
     }
 
     /**

--- a/src/main/java/seedu/innsync/model/tag/DateTag.java
+++ b/src/main/java/seedu/innsync/model/tag/DateTag.java
@@ -1,0 +1,66 @@
+package seedu.innsync.model.tag;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.innsync.commons.util.AppUtil.checkArgument;
+
+import java.time.LocalDateTime;
+
+/**
+ * Represents a Tag in the address book.
+ * Guarantees: immutable; name is valid as declared in {@link #isValidDateTagName(String)}
+ */
+public class DateTag {
+
+    public static final String MESSAGE_CONSTRAINTS = "Date tag names should in the format of YYYY-MM-DD";
+    public static final String VALIDATION_REGEX = "\\d{4}-\\d{2}-\\d{2}";
+
+    public final LocalDateTime dateTagDate;
+    public final String dateTagName;
+
+    /**
+     * Constructs a {@code Tag}.
+     *
+     * @param dateTagName A valid tag name.
+     */
+    public DateTag(String dateTagName) {
+        requireNonNull(dateTagName);
+        checkArgument(isValidDateTagName(dateTagName), MESSAGE_CONSTRAINTS);
+        this.dateTagName = dateTagName;
+        this.dateTagDate = LocalDateTime.parse(dateTagName);
+    }
+
+    /**
+     * Returns true if a given string is a valid tag name.
+     */
+    public static boolean isValidDateTagName(String test) {
+        return test.matches(VALIDATION_REGEX);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof Tag)) {
+            return false;
+        }
+
+        DateTag otherDateTag = (DateTag) other;
+        return dateTagName.equals(otherDateTag.dateTagName);
+    }
+
+    @Override
+    public int hashCode() {
+        return dateTagName.hashCode();
+    }
+
+    /**
+     * Format state as text for viewing.
+     */
+    public String toString() {
+        return '[' + dateTagName + ']';
+    }
+
+}

--- a/src/main/java/seedu/innsync/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/innsync/model/util/SampleDataUtil.java
@@ -24,22 +24,22 @@ public class SampleDataUtil {
     public static Person[] getSamplePersons() {
         return new Person[] {
             new Person(new Name("Alex Yeoh"), new Phone("87438807"), new Email("alexyeoh@example.com"),
-                new Address("Blk 30 Geylang Street 29, #06-40"),
+                new Address("Blk 30 Geylang Street 29, #06-40"), EMPTY_DATETAGS,
                 getTagSet("friends")),
             new Person(new Name("Bernice Yu"), new Phone("99272758"), new Email("berniceyu@example.com"),
-                new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"),
+                new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"), EMPTY_DATETAGS,
                 getTagSet("colleagues", "friends")),
             new Person(new Name("Charlotte Oliveiro"), new Phone("93210283"), new Email("charlotte@example.com"),
-                new Address("Blk 11 Ang Mo Kio Street 74, #11-04"),
+                new Address("Blk 11 Ang Mo Kio Street 74, #11-04"), EMPTY_DATETAGS,
                 getTagSet("neighbours")),
             new Person(new Name("David Li"), new Phone("91031282"), new Email("lidavid@example.com"),
-                new Address("Blk 436 Serangoon Gardens Street 26, #16-43"),
+                new Address("Blk 436 Serangoon Gardens Street 26, #16-43"), EMPTY_DATETAGS,
                 getTagSet("family")),
             new Person(new Name("Irfan Ibrahim"), new Phone("92492021"), new Email("irfan@example.com"),
-                new Address("Blk 47 Tampines Street 20, #17-35"),
+                new Address("Blk 47 Tampines Street 20, #17-35"), EMPTY_DATETAGS,
                 getTagSet("classmates")),
             new Person(new Name("Roy Balakrishnan"), new Phone("92624417"), new Email("royb@example.com"),
-                new Address("Blk 45 Aljunied Street 85, #11-31"),
+                new Address("Blk 45 Aljunied Street 85, #11-31"), EMPTY_DATETAGS,
                 getTagSet("colleagues"))
         };
     }

--- a/src/main/java/seedu/innsync/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/innsync/model/util/SampleDataUtil.java
@@ -11,13 +11,16 @@ import seedu.innsync.model.person.Email;
 import seedu.innsync.model.person.Name;
 import seedu.innsync.model.person.Person;
 import seedu.innsync.model.person.Phone;
-import seedu.innsync.model.tag.DateTag;
+import seedu.innsync.model.tag.BookingTag;
 import seedu.innsync.model.tag.Tag;
 
 /**
  * Contains utility methods for populating {@code AddressBook} with sample data.
  */
 public class SampleDataUtil {
+
+    public static final Set<BookingTag> EMPTY_DATETAGS = getBookingTagSet();
+
     public static Person[] getSamplePersons() {
         return new Person[] {
             new Person(new Name("Alex Yeoh"), new Phone("87438807"), new Email("alexyeoh@example.com"),
@@ -52,9 +55,9 @@ public class SampleDataUtil {
     /**
      * Returns a date tag set containing the list of strings given.
      */
-    public static Set<DateTag> getDateTagSet(String... strings) {
+    public static Set<BookingTag> getBookingTagSet(String... strings) {
         return Arrays.stream(strings)
-                .map(DateTag::new)
+                .map(BookingTag::new)
                 .collect(Collectors.toSet());
     }
 

--- a/src/main/java/seedu/innsync/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/innsync/model/util/SampleDataUtil.java
@@ -11,6 +11,7 @@ import seedu.innsync.model.person.Email;
 import seedu.innsync.model.person.Name;
 import seedu.innsync.model.person.Person;
 import seedu.innsync.model.person.Phone;
+import seedu.innsync.model.tag.DateTag;
 import seedu.innsync.model.tag.Tag;
 
 /**

--- a/src/main/java/seedu/innsync/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/innsync/model/util/SampleDataUtil.java
@@ -50,6 +50,15 @@ public class SampleDataUtil {
     }
 
     /**
+     * Returns a date tag set containing the list of strings given.
+     */
+    public static Set<DateTag> getDateTagSet(String... strings) {
+        return Arrays.stream(strings)
+                .map(DateTag::new)
+                .collect(Collectors.toSet());
+    }
+
+    /**
      * Returns a tag set containing the list of strings given.
      */
     public static Set<Tag> getTagSet(String... strings) {
@@ -57,5 +66,4 @@ public class SampleDataUtil {
                 .map(Tag::new)
                 .collect(Collectors.toSet());
     }
-
 }

--- a/src/main/java/seedu/innsync/storage/JsonAdaptedDateTag.java
+++ b/src/main/java/seedu/innsync/storage/JsonAdaptedDateTag.java
@@ -4,34 +4,34 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 import seedu.innsync.commons.exceptions.IllegalValueException;
-import seedu.innsync.model.tag.DateTag;
+import seedu.innsync.model.tag.BookingTag;
 import seedu.innsync.model.tag.Tag;
 
 /**
  * Jackson-friendly version of {@link Tag}.
  */
-class JsonAdaptedDateTag {
+class JsonAdaptedBookingTag {
 
-    private final String dateTagName;
+    private final String bookingTagName;
 
     /**
      * Constructs a {@code JsonAdaptedTag} with the given {@code tagName}.
      */
     @JsonCreator
-    public JsonAdaptedDateTag(String dateTagName) {
-        this.dateTagName = dateTagName;
+    public JsonAdaptedBookingTag(String bookingTagName) {
+        this.bookingTagName = bookingTagName;
     }
 
     /**
      * Converts a given {@code Tag} into this class for Jackson use.
      */
-    public JsonAdaptedDateTag(DateTag source) {
-        dateTagName = source.dateTagName;
+    public JsonAdaptedBookingTag(BookingTag source) {
+        bookingTagName = source.bookingTagName;
     }
 
     @JsonValue
-    public String getDateTagName() {
-        return dateTagName;
+    public String getBookingTagName() {
+        return bookingTagName;
     }
 
     /**
@@ -39,11 +39,11 @@ class JsonAdaptedDateTag {
      *
      * @throws IllegalValueException if there were any data constraints violated in the adapted tag.
      */
-    public DateTag toModelType() throws IllegalValueException {
-        if (!Tag.isValidTagName(dateTagName)) {
+    public BookingTag toModelType() throws IllegalValueException {
+        if (!Tag.isValidTagName(bookingTagName)) {
             throw new IllegalValueException(Tag.MESSAGE_CONSTRAINTS);
         }
-        return new DateTag(dateTagName);
+        return new BookingTag(bookingTagName);
     }
 
 }

--- a/src/main/java/seedu/innsync/storage/JsonAdaptedDateTag.java
+++ b/src/main/java/seedu/innsync/storage/JsonAdaptedDateTag.java
@@ -1,0 +1,49 @@
+package seedu.innsync.storage;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import seedu.innsync.commons.exceptions.IllegalValueException;
+import seedu.innsync.model.tag.DateTag;
+import seedu.innsync.model.tag.Tag;
+
+/**
+ * Jackson-friendly version of {@link Tag}.
+ */
+class JsonAdaptedDateTag {
+
+    private final String dateTagName;
+
+    /**
+     * Constructs a {@code JsonAdaptedTag} with the given {@code tagName}.
+     */
+    @JsonCreator
+    public JsonAdaptedDateTag(String dateTagName) {
+        this.dateTagName = dateTagName;
+    }
+
+    /**
+     * Converts a given {@code Tag} into this class for Jackson use.
+     */
+    public JsonAdaptedDateTag(DateTag source) {
+        dateTagName = source.dateTagName;
+    }
+
+    @JsonValue
+    public String getDateTagName() {
+        return dateTagName;
+    }
+
+    /**
+     * Converts this Jackson-friendly adapted tag object into the model's {@code Tag} object.
+     *
+     * @throws IllegalValueException if there were any data constraints violated in the adapted tag.
+     */
+    public DateTag toModelType() throws IllegalValueException {
+        if (!Tag.isValidTagName(dateTagName)) {
+            throw new IllegalValueException(Tag.MESSAGE_CONSTRAINTS);
+        }
+        return new DateTag(dateTagName);
+    }
+
+}

--- a/src/main/java/seedu/innsync/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/innsync/storage/JsonAdaptedPerson.java
@@ -15,7 +15,7 @@ import seedu.innsync.model.person.Email;
 import seedu.innsync.model.person.Name;
 import seedu.innsync.model.person.Person;
 import seedu.innsync.model.person.Phone;
-import seedu.innsync.model.tag.DateTag;
+import seedu.innsync.model.tag.BookingTag;
 import seedu.innsync.model.tag.Tag;
 
 /**
@@ -29,6 +29,7 @@ class JsonAdaptedPerson {
     private final String phone;
     private final String email;
     private final String address;
+    private final List<JsonAdaptedBookingTag> bookingTags = new ArrayList<>();
     private final List<JsonAdaptedTag> tags = new ArrayList<>();
 
     /**
@@ -36,12 +37,16 @@ class JsonAdaptedPerson {
      */
     @JsonCreator
     public JsonAdaptedPerson(@JsonProperty("name") String name, @JsonProperty("phone") String phone,
-            @JsonProperty("email") String email, @JsonProperty("address") String address,
-            @JsonProperty("tags") List<JsonAdaptedTag> tags) {
+                             @JsonProperty("email") String email, @JsonProperty("address") String address,
+                             @JsonProperty("bookingTags") List<JsonAdaptedBookingTag> bookingTags,
+                             @JsonProperty("tags") List<JsonAdaptedTag> tags) {
         this.name = name;
         this.phone = phone;
         this.email = email;
         this.address = address;
+        if (bookingTags != null) {
+            this.bookingTags.addAll(bookingTags);
+        }
         if (tags != null) {
             this.tags.addAll(tags);
         }
@@ -55,6 +60,9 @@ class JsonAdaptedPerson {
         phone = source.getPhone().value;
         email = source.getEmail().value;
         address = source.getAddress().value;
+        bookingTags.addAll(source.getBookingTags().stream()
+                .map(JsonAdaptedBookingTag::new)
+                .collect(Collectors.toList()));
         tags.addAll(source.getTags().stream()
                 .map(JsonAdaptedTag::new)
                 .collect(Collectors.toList()));
@@ -69,6 +77,10 @@ class JsonAdaptedPerson {
         final List<Tag> personTags = new ArrayList<>();
         for (JsonAdaptedTag tag : tags) {
             personTags.add(tag.toModelType());
+        }
+        final List<BookingTag> personBookingTags = new ArrayList<>();
+        for (JsonAdaptedBookingTag bookingTag : bookingTags) {
+            personBookingTags.add(bookingTag.toModelType());
         }
 
         if (name == null) {
@@ -103,8 +115,10 @@ class JsonAdaptedPerson {
         }
         final Address modelAddress = new Address(address);
 
+        final Set<BookingTag> modelBookingTags = new HashSet<>(personBookingTags);
+
         final Set<Tag> modelTags = new HashSet<>(personTags);
-        return new Person(modelName, modelPhone, modelEmail, modelAddress, modelTags);
+        return new Person(modelName, modelPhone, modelEmail, modelAddress, modelBookingTags, modelTags);
     }
 
 }

--- a/src/main/java/seedu/innsync/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/innsync/storage/JsonAdaptedPerson.java
@@ -15,6 +15,7 @@ import seedu.innsync.model.person.Email;
 import seedu.innsync.model.person.Name;
 import seedu.innsync.model.person.Person;
 import seedu.innsync.model.person.Phone;
+import seedu.innsync.model.tag.DateTag;
 import seedu.innsync.model.tag.Tag;
 
 /**

--- a/src/main/java/seedu/innsync/ui/PersonCard.java
+++ b/src/main/java/seedu/innsync/ui/PersonCard.java
@@ -39,6 +39,8 @@ public class PersonCard extends UiPart<Region> {
     @FXML
     private Label email;
     @FXML
+    private FlowPane bookingTags;
+    @FXML
     private FlowPane tags;
 
     /**
@@ -52,6 +54,9 @@ public class PersonCard extends UiPart<Region> {
         phone.setText(person.getPhone().value);
         address.setText(person.getAddress().value);
         email.setText(person.getEmail().value);
+        person.getBookingTags().stream()
+                .sorted(Comparator.comparing(bookingTag -> bookingTag.bookingTagName))
+                .forEach(bookingTag -> bookingTags.getChildren().add(new Label(bookingTag.bookingTagName)));
         person.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -28,6 +28,7 @@
         <Label fx:id="name" text="\$first" styleClass="cell_big_label" />
       </HBox>
       <FlowPane fx:id="tags" />
+      <FlowPane fx:id="bookingTags" />
       <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />
       <Label fx:id="address" styleClass="cell_small_label" text="\$address" />
       <Label fx:id="email" styleClass="cell_small_label" text="\$email" />

--- a/src/test/data/JsonSerializableAddressBookTest/duplicatePersonAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/duplicatePersonAddressBook.json
@@ -4,11 +4,13 @@
     "phone": "94351253",
     "email": "alice@example.com",
     "address": "123, Jurong West Ave 6, #08-111",
+    "bookingTag" : "",
     "tags": [ "friends" ]
   }, {
     "name": "Alice Pauline",
     "phone": "94351253",
     "email": "pauline@example.com",
+    "bookingTag" : "",
     "address": "4th street"
   } ]
 }

--- a/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
@@ -5,42 +5,49 @@
     "phone" : "94351253",
     "email" : "alice@example.com",
     "address" : "123, Jurong West Ave 6, #08-111",
+    "bookingTag" : "",
     "tags" : [ "friends" ]
   }, {
     "name" : "Benson Meier",
     "phone" : "98765432",
     "email" : "johnd@example.com",
     "address" : "311, Clementi Ave 2, #02-25",
+    "bookingTag" : "",
     "tags" : [ "owesMoney", "friends" ]
   }, {
     "name" : "Carl Kurz",
     "phone" : "95352563",
     "email" : "heinz@example.com",
     "address" : "wall street",
+    "bookingTag" : "",
     "tags" : [ ]
   }, {
     "name" : "Daniel Meier",
     "phone" : "87652533",
     "email" : "cornelia@example.com",
     "address" : "10th street",
+    "bookingTag" : "",
     "tags" : [ "friends" ]
   }, {
     "name" : "Elle Meyer",
     "phone" : "9482224",
     "email" : "werner@example.com",
     "address" : "michegan ave",
+    "bookingTag" : "",
     "tags" : [ ]
   }, {
     "name" : "Fiona Kunz",
     "phone" : "9482427",
     "email" : "lydia@example.com",
     "address" : "little tokyo",
+    "bookingTag" : "",
     "tags" : [ ]
   }, {
     "name" : "George Best",
     "phone" : "9482442",
     "email" : "anna@example.com",
     "address" : "4th street",
+    "bookingTag" : "",
     "tags" : [ ]
   } ]
 }

--- a/src/test/java/seedu/innsync/logic/commands/EditPersonDescriptorTest.java
+++ b/src/test/java/seedu/innsync/logic/commands/EditPersonDescriptorTest.java
@@ -64,7 +64,8 @@ public class EditPersonDescriptorTest {
                 + editPersonDescriptor.getName().orElse(null) + ", phone="
                 + editPersonDescriptor.getPhone().orElse(null) + ", email="
                 + editPersonDescriptor.getEmail().orElse(null) + ", address="
-                + editPersonDescriptor.getAddress().orElse(null) + ", tags="
+                + editPersonDescriptor.getAddress().orElse(null) + ", dateTags="
+                + editPersonDescriptor.getDateTags().orElse(null) + ", tags="
                 + editPersonDescriptor.getTags().orElse(null) + "}";
         assertEquals(expected, editPersonDescriptor.toString());
     }

--- a/src/test/java/seedu/innsync/logic/commands/EditPersonDescriptorTest.java
+++ b/src/test/java/seedu/innsync/logic/commands/EditPersonDescriptorTest.java
@@ -64,8 +64,8 @@ public class EditPersonDescriptorTest {
                 + editPersonDescriptor.getName().orElse(null) + ", phone="
                 + editPersonDescriptor.getPhone().orElse(null) + ", email="
                 + editPersonDescriptor.getEmail().orElse(null) + ", address="
-                + editPersonDescriptor.getAddress().orElse(null) + ", dateTags="
-                + editPersonDescriptor.getDateTags().orElse(null) + ", tags="
+                + editPersonDescriptor.getAddress().orElse(null) + ", bookingTags="
+                + editPersonDescriptor.getBookingTags().orElse(null) + ", tags="
                 + editPersonDescriptor.getTags().orElse(null) + "}";
         assertEquals(expected, editPersonDescriptor.toString());
     }

--- a/src/test/java/seedu/innsync/model/person/PersonTest.java
+++ b/src/test/java/seedu/innsync/model/person/PersonTest.java
@@ -93,7 +93,8 @@ public class PersonTest {
     @Test
     public void toStringMethod() {
         String expected = Person.class.getCanonicalName() + "{name=" + ALICE.getName() + ", phone=" + ALICE.getPhone()
-                + ", email=" + ALICE.getEmail() + ", address=" + ALICE.getAddress() + ", tags=" + ALICE.getTags() + "}";
+                + ", email=" + ALICE.getEmail() + ", address=" + ALICE.getAddress()
+                + ", dateTags=" + ALICE.getDateTags() + ", tags=" + ALICE.getTags() + "}";
         assertEquals(expected, ALICE.toString());
     }
 }

--- a/src/test/java/seedu/innsync/model/person/PersonTest.java
+++ b/src/test/java/seedu/innsync/model/person/PersonTest.java
@@ -94,7 +94,7 @@ public class PersonTest {
     public void toStringMethod() {
         String expected = Person.class.getCanonicalName() + "{name=" + ALICE.getName() + ", phone=" + ALICE.getPhone()
                 + ", email=" + ALICE.getEmail() + ", address=" + ALICE.getAddress()
-                + ", dateTags=" + ALICE.getDateTags() + ", tags=" + ALICE.getTags() + "}";
+                + ", bookingTags=" + ALICE.getBookingTags() + ", tags=" + ALICE.getTags() + "}";
         assertEquals(expected, ALICE.toString());
     }
 }

--- a/src/test/java/seedu/innsync/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/innsync/storage/JsonAdaptedPersonTest.java
@@ -28,6 +28,9 @@ public class JsonAdaptedPersonTest {
     private static final String VALID_PHONE = BENSON.getPhone().toString();
     private static final String VALID_EMAIL = BENSON.getEmail().toString();
     private static final String VALID_ADDRESS = BENSON.getAddress().toString();
+    private static final List<JsonAdaptedDateTag> VALID_DATETAGS = BENSON.getDateTags().stream()
+            .map(JsonAdaptedDateTag::new)
+            .collect(Collectors.toList());
     private static final List<JsonAdaptedTag> VALID_TAGS = BENSON.getTags().stream()
             .map(JsonAdaptedTag::new)
             .collect(Collectors.toList());
@@ -41,14 +44,16 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_invalidName_throwsIllegalValueException() {
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(INVALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+                new JsonAdaptedPerson(INVALID_NAME, VALID_PHONE, VALID_EMAIL,
+                        VALID_ADDRESS, VALID_DATETAGS, VALID_TAGS);
         String expectedMessage = Name.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_nullName_throwsIllegalValueException() {
-        JsonAdaptedPerson person = new JsonAdaptedPerson(null, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+        JsonAdaptedPerson person = new JsonAdaptedPerson(null, VALID_PHONE, VALID_EMAIL,
+                VALID_ADDRESS, VALID_DATETAGS, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -56,14 +61,16 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_invalidPhone_throwsIllegalValueException() {
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, INVALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+                new JsonAdaptedPerson(VALID_NAME, INVALID_PHONE, VALID_EMAIL,
+                        VALID_ADDRESS, VALID_DATETAGS, VALID_TAGS);
         String expectedMessage = Phone.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_nullPhone_throwsIllegalValueException() {
-        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, null, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, null, VALID_EMAIL,
+                VALID_ADDRESS, VALID_DATETAGS, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Phone.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -71,14 +78,16 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_invalidEmail_throwsIllegalValueException() {
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, INVALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, INVALID_EMAIL,
+                        VALID_ADDRESS, VALID_DATETAGS, VALID_TAGS);
         String expectedMessage = Email.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_nullEmail_throwsIllegalValueException() {
-        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, null, VALID_ADDRESS, VALID_TAGS);
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, null,
+                VALID_ADDRESS, VALID_DATETAGS, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Email.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -86,14 +95,16 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_invalidAddress_throwsIllegalValueException() {
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, INVALID_ADDRESS, VALID_TAGS);
+                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL,
+                        INVALID_ADDRESS, VALID_DATETAGS, VALID_TAGS);
         String expectedMessage = Address.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_nullAddress_throwsIllegalValueException() {
-        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, null, VALID_TAGS);
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL,
+                null, VALID_DATETAGS, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Address.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -103,7 +114,8 @@ public class JsonAdaptedPersonTest {
         List<JsonAdaptedTag> invalidTags = new ArrayList<>(VALID_TAGS);
         invalidTags.add(new JsonAdaptedTag(INVALID_TAG));
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, invalidTags);
+                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL,
+                        VALID_ADDRESS, VALID_DATETAGS, invalidTags);
         assertThrows(IllegalValueException.class, person::toModelType);
     }
 

--- a/src/test/java/seedu/innsync/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/innsync/storage/JsonAdaptedPersonTest.java
@@ -28,8 +28,8 @@ public class JsonAdaptedPersonTest {
     private static final String VALID_PHONE = BENSON.getPhone().toString();
     private static final String VALID_EMAIL = BENSON.getEmail().toString();
     private static final String VALID_ADDRESS = BENSON.getAddress().toString();
-    private static final List<JsonAdaptedDateTag> VALID_DATETAGS = BENSON.getDateTags().stream()
-            .map(JsonAdaptedDateTag::new)
+    private static final List<JsonAdaptedBookingTag> VALID_DATETAGS = BENSON.getBookingTags().stream()
+            .map(JsonAdaptedBookingTag::new)
             .collect(Collectors.toList());
     private static final List<JsonAdaptedTag> VALID_TAGS = BENSON.getTags().stream()
             .map(JsonAdaptedTag::new)

--- a/src/test/java/seedu/innsync/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/innsync/testutil/PersonBuilder.java
@@ -8,7 +8,7 @@ import seedu.innsync.model.person.Email;
 import seedu.innsync.model.person.Name;
 import seedu.innsync.model.person.Person;
 import seedu.innsync.model.person.Phone;
-import seedu.innsync.model.tag.DateTag;
+import seedu.innsync.model.tag.BookingTag;
 import seedu.innsync.model.tag.Tag;
 import seedu.innsync.model.util.SampleDataUtil;
 
@@ -26,7 +26,7 @@ public class PersonBuilder {
     private Phone phone;
     private Email email;
     private Address address;
-    private Set<DateTag> dateTag;
+    private Set<BookingTag> bookingTag;
     private Set<Tag> tags;
 
     /**
@@ -37,7 +37,7 @@ public class PersonBuilder {
         phone = new Phone(DEFAULT_PHONE);
         email = new Email(DEFAULT_EMAIL);
         address = new Address(DEFAULT_ADDRESS);
-        dateTag = new HashSet<>();
+        bookingTag = new HashSet<>();
         tags = new HashSet<>();
     }
 
@@ -49,7 +49,7 @@ public class PersonBuilder {
         phone = personToCopy.getPhone();
         email = personToCopy.getEmail();
         address = personToCopy.getAddress();
-        dateTag = personToCopy.getDateTags();
+        bookingTag = personToCopy.getBookingTags();
         tags = new HashSet<>(personToCopy.getTags());
     }
 
@@ -64,8 +64,8 @@ public class PersonBuilder {
     /**
      *
      */
-    public PersonBuilder withDateTag(String dateTag) {
-        this.dateTag = SampleDataUtil.getDateTagSet(dateTag);
+    public PersonBuilder withBookingTag(String bookingTag) {
+        this.bookingTag = SampleDataUtil.getBookingTagSet(bookingTag);
         return this;
     }
 
@@ -102,7 +102,7 @@ public class PersonBuilder {
     }
 
     public Person build() {
-        return new Person(name, phone, email, address, tags);
+        return new Person(name, phone, email, address, bookingTag, tags);
     }
 
 }

--- a/src/test/java/seedu/innsync/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/innsync/testutil/PersonBuilder.java
@@ -26,6 +26,7 @@ public class PersonBuilder {
     private Phone phone;
     private Email email;
     private Address address;
+    private Set<DateTag> dateTag;
     private Set<Tag> tags;
 
     /**
@@ -36,6 +37,7 @@ public class PersonBuilder {
         phone = new Phone(DEFAULT_PHONE);
         email = new Email(DEFAULT_EMAIL);
         address = new Address(DEFAULT_ADDRESS);
+        dateTag = new HashSet<>();
         tags = new HashSet<>();
     }
 
@@ -47,6 +49,7 @@ public class PersonBuilder {
         phone = personToCopy.getPhone();
         email = personToCopy.getEmail();
         address = personToCopy.getAddress();
+        dateTag = personToCopy.getDateTags();
         tags = new HashSet<>(personToCopy.getTags());
     }
 
@@ -55,6 +58,14 @@ public class PersonBuilder {
      */
     public PersonBuilder withName(String name) {
         this.name = new Name(name);
+        return this;
+    }
+
+    /**
+     *
+     */
+    public PersonBuilder withDateTag(String dateTag) {
+        this.dateTag = SampleDataUtil.getDateTagSet(dateTag);
         return this;
     }
 

--- a/src/test/java/seedu/innsync/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/innsync/testutil/PersonBuilder.java
@@ -8,6 +8,7 @@ import seedu.innsync.model.person.Email;
 import seedu.innsync.model.person.Name;
 import seedu.innsync.model.person.Person;
 import seedu.innsync.model.person.Phone;
+import seedu.innsync.model.tag.DateTag;
 import seedu.innsync.model.tag.Tag;
 import seedu.innsync.model.util.SampleDataUtil;
 


### PR DESCRIPTION
Booking Tag now supports tagging via {property} from/{start-date} to/{end-date}. Prefix update to b/ (instead of d/).
Validation done with regex and DateTimeFormatter in yyyy-MM-dd.

Tests are currently run with empty booking tags, will need to update with new tests.