### PR TITLE
Update tag command messages

### DIFF
--- a/src/main/java/seedu/innsync/logic/commands/TagCommand.java
+++ b/src/main/java/seedu/innsync/logic/commands/TagCommand.java
@@ -37,6 +37,8 @@ public class TagCommand extends Command {
             Messages.MESSAGE_COMMAND_SUCCESS, "Tag", "%s has been added to the contact's tag list!");
     public static final String MESSAGE_FAILURE = String.format(
             Messages.MESSAGE_COMMAND_FAILURE, "Tag", "%s already exists in the contact's tag list!");
+    public static final String MESSAGE_FAILURE_OVERLAP = String.format(
+            Messages.MESSAGE_COMMAND_FAILURE, "Tag", "%s overlaps with existing booking tag!");
 
     private final Index index;
     private final Set<Tag> tagList;
@@ -91,8 +93,11 @@ public class TagCommand extends Command {
 
         for (BookingTag bookingTag : bookingTags) {
             for (BookingTag existingTag : updatedBookingTags) {
-                if (isOverlapping(existingTag, bookingTag)) {
+                if (existingTag.equals(bookingTag)) {
                     throw new CommandException(String.format(MESSAGE_FAILURE, bookingTag.toPrettier()));
+                }
+                if (isOverlapping(existingTag, bookingTag)) {
+                    throw new CommandException(String.format(MESSAGE_FAILURE_OVERLAP, bookingTag.toPrettier()));
                 }
             }
             updatedBookingTags.add(bookingTag);

--- a/src/main/java/seedu/innsync/logic/commands/TagCommand.java
+++ b/src/main/java/seedu/innsync/logic/commands/TagCommand.java
@@ -34,7 +34,7 @@ public class TagCommand extends Command {
             + PREFIX_BOOKINGTAG + "{property} from/{start-date} to/{end-date}\n"
             + "Example: " + COMMAND_WORD + " 1 t/friend b/Beach House from/2025-06-01 to/2025-06-10";
     public static final String MESSAGE_SUCCESS = String.format(
-            Messages.MESSAGE_COMMAND_SUCCESS, "Tag", "%s has been added to the contact's tag list!");
+            Messages.MESSAGE_COMMAND_SUCCESS, "Tag", "%s's tag list has been updated!");
     public static final String MESSAGE_FAILURE = String.format(
             Messages.MESSAGE_COMMAND_FAILURE, "Tag", "%s already exists in the contact's tag list!");
     public static final String MESSAGE_FAILURE_OVERLAP = String.format(

--- a/src/test/java/seedu/innsync/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/innsync/logic/commands/CommandTestUtil.java
@@ -87,6 +87,10 @@ public class CommandTestUtil {
     public static final EditCommand.EditPersonDescriptor DESC_AMY;
     public static final EditCommand.EditPersonDescriptor DESC_BOB;
 
+    // logger
+    private static final java.util.logging.Logger logger =
+            java.util.logging.Logger.getLogger(CommandTestUtil.class.getName());
+
     static {
         DESC_AMY = new EditPersonDescriptorBuilder().withName(VALID_NAME_AMY)
                 .withPhone(VALID_PHONE_AMY).withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY)
@@ -167,6 +171,9 @@ public class CommandTestUtil {
             } catch (CommandException ce) {
                 boolean matches = Arrays.stream(expectedMessages).anyMatch(ce.getMessage()::equals);
                 if (!matches) {
+                    logger.warning("CommandException message does not match any expected messages.");
+                    logger.warning("Expected messages: " + Arrays.toString(expectedMessages));
+                    logger.warning("Actual message: " + ce.getMessage());
                     throw new AssertionError("CommandException message does not match any expected messages.");
                 }
                 throw ce;

--- a/src/test/java/seedu/innsync/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/innsync/logic/commands/CommandTestUtil.java
@@ -87,10 +87,6 @@ public class CommandTestUtil {
     public static final EditCommand.EditPersonDescriptor DESC_AMY;
     public static final EditCommand.EditPersonDescriptor DESC_BOB;
 
-    // logger
-    private static final java.util.logging.Logger logger =
-            java.util.logging.Logger.getLogger(CommandTestUtil.class.getName());
-
     static {
         DESC_AMY = new EditPersonDescriptorBuilder().withName(VALID_NAME_AMY)
                 .withPhone(VALID_PHONE_AMY).withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY)
@@ -171,9 +167,6 @@ public class CommandTestUtil {
             } catch (CommandException ce) {
                 boolean matches = Arrays.stream(expectedMessages).anyMatch(ce.getMessage()::equals);
                 if (!matches) {
-                    logger.warning("CommandException message does not match any expected messages.");
-                    logger.warning("Expected messages: " + Arrays.toString(expectedMessages));
-                    logger.warning("Actual message: " + ce.getMessage());
                     throw new AssertionError("CommandException message does not match any expected messages.");
                 }
                 throw ce;

--- a/src/test/java/seedu/innsync/logic/commands/TagCommandTest.java
+++ b/src/test/java/seedu/innsync/logic/commands/TagCommandTest.java
@@ -137,14 +137,14 @@ public class TagCommandTest {
     public void execute_overlappingBookingTags_failure() {
         Index indexLastPerson = Index.fromOneBased(model.getPersonList().size());
 
-        BookingTag originalBookingTag = new BookingTag(VALID_BOOKINGTAG_BEACHHOUSE);
+        BookingTag originalBookingTag = new BookingTag(VALID_BOOKINGTAG_HOTEL);
         BookingTag overlappingBookingTag = new BookingTag(OVERLAPPING_BOOKINGTAG_INN);
 
         TagCommand bookingTagCommand = new TagCommand(indexLastPerson, null,
                 Set.of(originalBookingTag, overlappingBookingTag));
 
-        String expectedMessage1 = String.format(TagCommand.MESSAGE_FAILURE, overlappingBookingTag.toPrettier());
-        String expectedMessage2 = String.format(TagCommand.MESSAGE_FAILURE, originalBookingTag.toPrettier());
+        String expectedMessage1 = String.format(TagCommand.MESSAGE_FAILURE_OVERLAP, overlappingBookingTag.toPrettier());
+        String expectedMessage2 = String.format(TagCommand.MESSAGE_FAILURE_OVERLAP, originalBookingTag.toPrettier());
 
         assertCommandFailure(bookingTagCommand, model, new String[] {expectedMessage1, expectedMessage2});
     }


### PR DESCRIPTION
Now shows different error messages for
1. Completely same details existing booking tag, and
![image](https://github.com/user-attachments/assets/6445baab-fcba-4193-817f-9ee5d97d99ab)

2. Overlapping with existing booking tag
![image](https://github.com/user-attachments/assets/7e6c80b1-0ee0-4b4b-8dd1-36d8d05c2899)

Fixes #319 
