### PR TITLE
Fix tag command date error messages

### DIFF
--- a/src/main/java/seedu/innsync/model/tag/BookingTag.java
+++ b/src/main/java/seedu/innsync/model/tag/BookingTag.java
@@ -145,7 +145,7 @@ public class BookingTag {
 
         // check if parser rounded down the date
         if (parsedDate.getDayOfMonth() != Integer.parseInt(date.substring(8, 10))) {
-            throw new IllegalArgumentException("Invalid date: " + date);
+            throw new DateTimeParseException("Invalid date", date, 0);
         }
     }
 

--- a/src/main/java/seedu/innsync/model/tag/BookingTag.java
+++ b/src/main/java/seedu/innsync/model/tag/BookingTag.java
@@ -30,7 +30,7 @@ public class BookingTag {
             "Booking tag", 170);
     public static final String MESSAGE_STARTDATE_EMPTY = String.format(Messages.MESSAGE_EMPTY_FIELD, "Start date");
     public static final String MESSAGE_STARTDATE_INVALID = String.format(Messages.MESSAGE_INVALID_FIELD,
-    "Start date", "Start date is invalid.");
+        "Start date", "Start date is invalid.");
     public static final String MESSAGE_ENDDATE_EMPTY = String.format(Messages.MESSAGE_EMPTY_FIELD, "End date");
     public static final String MESSAGE_ENDDATE_INVALID = String.format(Messages.MESSAGE_INVALID_FIELD,
             "End date", "End date is invalid.");

--- a/src/main/java/seedu/innsync/model/tag/BookingTag.java
+++ b/src/main/java/seedu/innsync/model/tag/BookingTag.java
@@ -28,8 +28,12 @@ public class BookingTag {
             "No booking tag fields");
     public static final String MESSAGE_PROPERTY_LENGTH = String.format(Messages.MESSAGE_MAX_LENGTH_EXCEEDED,
             "Booking tag", 170);
-    public static final String MESSAGE_STARTDATE_INVALID = String.format(Messages.MESSAGE_EMPTY_FIELD, "Start date");
-    public static final String MESSAGE_ENDDATE_INVALID = String.format(Messages.MESSAGE_EMPTY_FIELD, "End date");
+    public static final String MESSAGE_STARTDATE_EMPTY = String.format(Messages.MESSAGE_EMPTY_FIELD, "Start date");
+    public static final String MESSAGE_STARTDATE_INVALID = String.format(Messages.MESSAGE_INVALID_FIELD,
+    "Start date", "Start date is invalid.");
+    public static final String MESSAGE_ENDDATE_EMPTY = String.format(Messages.MESSAGE_EMPTY_FIELD, "End date");
+    public static final String MESSAGE_ENDDATE_INVALID = String.format(Messages.MESSAGE_INVALID_FIELD,
+            "End date", "End date is invalid.");
     public static final String MESSAGE_STARTDATE_AFTER_ENDDATE =
             "Error: Booking tag start date must be before end date.";
 
@@ -97,10 +101,10 @@ public class BookingTag {
         }
 
         if (!startDate.matches(REGEX_NOT_EMPTY)) {
-            throw new IllegalArgumentException(MESSAGE_STARTDATE_INVALID);
+            throw new IllegalArgumentException(MESSAGE_STARTDATE_EMPTY);
         }
         if (!endDate.matches(REGEX_NOT_EMPTY)) {
-            throw new IllegalArgumentException(MESSAGE_ENDDATE_INVALID);
+            throw new IllegalArgumentException(MESSAGE_ENDDATE_EMPTY);
         }
         try {
             checkValidDate(startDate);

--- a/src/main/java/seedu/innsync/model/tag/BookingTag.java
+++ b/src/main/java/seedu/innsync/model/tag/BookingTag.java
@@ -145,7 +145,7 @@ public class BookingTag {
 
         // check if parser rounded down the date
         if (parsedDate.getDayOfMonth() != Integer.parseInt(date.substring(8, 10))) {
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException("Invalid date: " + date);
         }
     }
 

--- a/src/test/java/seedu/innsync/model/tag/BookingTagTest.java
+++ b/src/test/java/seedu/innsync/model/tag/BookingTagTest.java
@@ -51,6 +51,9 @@ public class BookingTagTest {
     void constructor_invalidLeapYearBookingTag_throwsIllegalArgumentException() {
         assertThrows(IllegalArgumentException.class, () -> new BookingTag("LeapYear from/2024-02-30 to/2024-03-01"));
         assertThrows(IllegalArgumentException.class, () -> new BookingTag("LeapYear from/2024-01-29 to/2024-02-30"));
+
+        assertThrows(IllegalArgumentException.class, () -> new BookingTag("NotLeapYear from/2025-02-29 to/2025-03-01"));
+        assertThrows(IllegalArgumentException.class, () -> new BookingTag("NotLeapYear from/2025-01-29 to/2025-02-29"));
     }
 
     @Test


### PR DESCRIPTION
Fix invalid start and end date messages.

[Non-leap year dates] Fixes #316 
![image](https://github.com/user-attachments/assets/9a6869cc-95bb-4738-950c-0856b4d41d40)
![image](https://github.com/user-attachments/assets/703b37a2-7067-4ba6-a3a4-f9ded7f4f367)

[Invalid leap year dates] Fixes #323 
![image](https://github.com/user-attachments/assets/ea681de9-57a4-4e24-964e-1517c64e2539)
![image](https://github.com/user-attachments/assets/985e8f7f-aeb3-4c61-983a-4ac7052b75bc)

